### PR TITLE
Migrate to ESM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+dist/
 node_modules/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1 (2020-05-14)
+
+* Migrate to ESM
+
 ## 0.1.0 (2020-05-04)
 
 Initial release

--- a/README.md
+++ b/README.md
@@ -8,12 +8,21 @@ It implements support for logical assignments as defined in the stage 3 proposal
 
 ## Usage
 
-This module provides a plugin that can be used to extend the Acorn `Parser` class to parse logical assignments:
+This module provides a plugin that can be used to extend the Acorn `Parser` class to parse logical assignments.
+You can either choose to use it via CommonJS (for example in Node.js) like this
 
 ```javascript
 var acorn = require('acorn');
 var logicalAssignment = require('acorn-logical-assignment');
 acorn.Parser.extend(logicalAssignment).parse('x ||= y');
+```
+
+or as an ECMAScript module like this:
+
+```javascript
+import {Parser} from 'acorn';
+import logicalAssignment from 'path/to/acorn-logical-assignment.mjs';
+Parser.extend(logicalAssignment).parse('x ||= y');
 ```
 
 ## License

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "name": "acorn-logical-assignment",
-  "version": "0.1.0",
-  "description": "Support fot logical assignments in acorn",
-  "main": "index.js",
+  "version": "0.1.1",
+  "description": "Support for logical assignments in acorn",
+  "main": "dist/acorn-logical-assignment.js",
+  "module": "dist/acorn-logical-assignment.mjs",
   "repository": "https://github.com/acornjs/acorn-logical-assignment",
   "author": "Adrian Heine <mail@adrianheine.de>",
   "license": "MIT",
@@ -10,6 +11,8 @@
     "node": ">=4.8.2"
   },
   "scripts": {
+    "build": "rollup -c rollup.config.js",
+    "prepare": "npm run build",
     "test": "mocha",
     "test:test262": "node run_test262.js",
     "lint": "eslint -c .eslintrc.json ."
@@ -22,6 +25,7 @@
     "eslint": "^6",
     "eslint-plugin-node": "^11",
     "mocha": "^7",
+    "rollup": "^2.10.0",
     "test262": "git+https://github.com/tc39/test262.git#57fa74b170e9554bfe89a29c10de2447fe7d3b27",
     "test262-parser-runner": "^0.5.0"
   }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,15 @@
+export default {
+	input: "src/index.js",
+	output: [
+		{
+			file: "dist/acorn-logical-assignment.js",
+			format: "cjs",
+			sourcemap: true
+		},
+		{
+			file: "dist/acorn-logical-assignment.mjs",
+			format: "es",
+			sourcemap: true
+		}
+	]
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,4 @@
-"use strict"
-
-module.exports = function(Parser) {
+export default function logicalAssignment(Parser) {
   const acorn = Parser.acorn || require("acorn")
   const tt = acorn.tokTypes
   return class extends Parser {


### PR DESCRIPTION
We've recently migrated Chrome DevTools to ESM, and have traditionally
been using acorn as the parser for various features including the
prettifier. In the context of https://crbug.com/1080569 we are looking
into including logical assignment support in Chrome DevTools via this
plugin, and in order to make that easier with our build system, I've
added support for ESM output here in addition to the CJS output
(together with @TimvdLippe).